### PR TITLE
Fixes for Bloodsail Buccaneers mobs reputation

### DIFF
--- a/content.lua
+++ b/content.lua
@@ -200,10 +200,10 @@ function RPH_InitEnFactionGains()
 	-- Bloodsail Buccaners
 	RPH_AddMob(87, 1, 8, "Booty Bay Bruiser", 25, zone.Stranglethorn_Vale)
 	RPH_AddMob(87, 1, 8, "Booty Bay Elite", 25, zone.Stranglethorn_Vale)
-	RPH_AddMob(87, 1, 6, "Captain Steelgut", 25, zone.Arathi_Highlands)
-	RPH_AddMob(87, 1, 6, "First Mate Nilzlix", 25, zone.Arathi_Highlands)
 	RPH_AddMob(87, 1, 8, "Baron Revilgaz", 5, zone.Stranglethorn_Vale)
 	RPH_AddMob(87, 1, 8, "Blackwater Deckhand", 5, zone.Stranglethorn_Vale)
+	RPH_AddMob(87, 1, 6, "Captain Steelgut", 25, zone.Arathi_Highlands)
+	RPH_AddMob(87, 1, 6, "First Mate Nilzlix", 25, zone.Arathi_Highlands)
 	RPH_AddMob(87, 1, 6, "Pirates at Faldir's Cove", 5, zone.Arathi_Highlands)
 	RPH_AddMob(87, 1, 7, "Jazzrik and Rigglefuzz", 5, zone.Badlands)
 

--- a/content.lua
+++ b/content.lua
@@ -198,12 +198,14 @@ function RPH_InitEnFactionGains()
 	RPH_AddMob(529, 4, 8, "Bosses in Stratholme and Scholomance", 25)
 
 	-- Bloodsail Buccaners
-	RPH_AddMob(87, 4, 8, "Booty Bay Bruiser", 25, zone.Stranglethorn_Vale)
-	RPH_AddMob(87, 4, 8, "Booty Bay Elite", 25, zone.Stranglethorn_Vale)
-	RPH_AddMob(87, 4, 8, "Baron Revilgaz", 5, zone.Stranglethorn_Vale)
-	RPH_AddMob(87, 4, 8, "Blackwater Deckhand", 5, zone.Stranglethorn_Vale)
-	RPH_AddMob(87, 4, 6, "Pirates at Faldir's Cove", zone.Arathi_Highlands)
-	RPH_AddMob(87, 4, 7, "Jazzrik and Rigglefuzz", 5, zone.Badlands)
+	RPH_AddMob(87, 1, 8, "Booty Bay Bruiser", 25, zone.Stranglethorn_Vale)
+	RPH_AddMob(87, 1, 8, "Booty Bay Elite", 25, zone.Stranglethorn_Vale)
+	RPH_AddMob(87, 1, 6, "Captain Steelgut", 25, zone.Arathi_Highlands)
+	RPH_AddMob(87, 1, 6, "First Mate Nilzlix", 25, zone.Arathi_Highlands)
+	RPH_AddMob(87, 1, 8, "Baron Revilgaz", 5, zone.Stranglethorn_Vale)
+	RPH_AddMob(87, 1, 8, "Blackwater Deckhand", 5, zone.Stranglethorn_Vale)
+	RPH_AddMob(87, 1, 6, "Pirates at Faldir's Cove", 5, zone.Arathi_Highlands)
+	RPH_AddMob(87, 1, 7, "Jazzrik and Rigglefuzz", 5, zone.Badlands)
 
 	-- Brood of Nozdormu
 	RPH_AddMob(910, 1, 4, "Anubisath Defender", 100, "Temple of Ahn'Qiraj")


### PR DESCRIPTION
Some fixes for Bloodsail Buccaneers mobs:
1. Mobs didn't appear in list until Neutral standing (while killing them yield rep from Hostile)
1. Added a few more Faldir's Cove mobs (based on https://vanilla-wow.fandom.com/wiki/Bloodsail_Buccaneers_reputation_guide)
1. Pirates at Faldir's Cove had 1400ish reputation (missed rep param - so it was zone ID i suppose)
